### PR TITLE
Add usage data support for cached tokens and recursive openai requests

### DIFF
--- a/packages/conversation/package-lock.json
+++ b/packages/conversation/package-lock.json
@@ -12,7 +12,7 @@
         "@proteinjs/util": "1.4.1",
         "@proteinjs/util-node": "1.4.1",
         "fs-extra": "11.1.1",
-        "openai": "4.52.0",
+        "openai": "4.85.3",
         "readline-sync": "1.4.10",
         "tiktoken": "1.0.15",
         "typescript": "5.2.2"
@@ -4192,9 +4192,10 @@
       }
     },
     "node_modules/openai": {
-      "version": "4.52.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-4.52.0.tgz",
-      "integrity": "sha512-xmiNcdA9QJ5wffHpZDpIsge6AsPTETJ6h5iqDNuFQ7qGSNtonHn8Qe0VHy4UwLE8rBWiSqh4j+iSvuYZSeKkPg==",
+      "version": "4.85.3",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-4.85.3.tgz",
+      "integrity": "sha512-KTMXAK6FPd2IvsPtglMt0J1GyVrjMxCYzu/mVbCPabzzquSJoZlYpHtE0p0ScZPyt11XTc757xSO4j39j5g+Xw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -4202,11 +4203,22 @@
         "agentkeepalive": "^4.2.1",
         "form-data-encoder": "1.7.2",
         "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7",
-        "web-streams-polyfill": "^3.2.1"
+        "node-fetch": "^2.6.7"
       },
       "bin": {
         "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/openai/node_modules/@types/node": {
@@ -5149,14 +5161,6 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {

--- a/packages/conversation/package.json
+++ b/packages/conversation/package.json
@@ -32,7 +32,7 @@
     "@proteinjs/util": "1.4.1",
     "@proteinjs/util-node": "1.4.1",
     "fs-extra": "11.1.1",
-    "openai": "4.52.0",
+    "openai": "4.85.3",
     "readline-sync": "1.4.10",
     "tiktoken": "1.0.15",
     "typescript": "5.2.2"

--- a/packages/conversation/src/OpenAiStreamProcessor.ts
+++ b/packages/conversation/src/OpenAiStreamProcessor.ts
@@ -91,6 +91,7 @@ export class OpenAiStreamProcessor {
           } else if (chunk.usage) {
             this.usageDataAccumulator.addTokenUsage({
               promptTokens: chunk.usage.prompt_tokens,
+              cachedPromptTokens: chunk.usage.prompt_tokens_details?.cached_tokens ?? 0,
               completionTokens: chunk.usage.completion_tokens,
               totalTokens: chunk.usage.total_tokens,
             });

--- a/packages/conversation/src/UsageData.ts
+++ b/packages/conversation/src/UsageData.ts
@@ -2,6 +2,7 @@ import { TiktokenModel } from 'tiktoken';
 
 export type TokenUsage = {
   promptTokens: number;
+  cachedPromptTokens: number;
   completionTokens: number;
   totalTokens: number;
 };
@@ -38,11 +39,13 @@ export class UsageDataAccumulator {
       model,
       initialRequestTokenUsage: {
         promptTokens: 0,
+        cachedPromptTokens: 0,
         completionTokens: 0,
         totalTokens: 0,
       },
       totalTokenUsage: {
         promptTokens: 0,
+        cachedPromptTokens: 0,
         completionTokens: 0,
         totalTokens: 0,
       },
@@ -60,6 +63,7 @@ export class UsageDataAccumulator {
     }
     this.usageData.totalTokenUsage = {
       promptTokens: this.usageData.totalTokenUsage.promptTokens + tokenUsage.promptTokens,
+      cachedPromptTokens: this.usageData.totalTokenUsage.promptTokens + tokenUsage.cachedPromptTokens,
       completionTokens: this.usageData.totalTokenUsage.completionTokens + tokenUsage.completionTokens,
       totalTokens: this.usageData.totalTokenUsage.totalTokens + tokenUsage.totalTokens,
     };

--- a/packages/conversation/src/UsageDataContext.ts
+++ b/packages/conversation/src/UsageDataContext.ts
@@ -1,0 +1,42 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { UsageDataAccumulator } from './UsageData';
+import { TiktokenModel } from 'tiktoken';
+
+interface ContextData {
+  data: Map<TiktokenModel, UsageDataAccumulator>;
+}
+
+export class UsageDataAccumulatorContext {
+  private static readonly storage = new AsyncLocalStorage<ContextData>();
+
+  /**
+   * Returns the `UsageDataAccumulator` stored in context depending on the `model` param provided.
+   * If no `UsageDataAccumulator` is stored, returns `undefined`.
+   */
+  getUsageDataAccumulator(model: TiktokenModel): UsageDataAccumulator | undefined {
+    const context = UsageDataAccumulatorContext.storage.getStore();
+
+    if (!context || !context.data.has(model)) {
+      return;
+    }
+
+    return context.data.get(model);
+  }
+
+  runInContext<T>(usageDataAccumulator: UsageDataAccumulator, fn: () => Promise<T>): Promise<T> {
+    const initialContext: ContextData = {
+      data: new Map([[usageDataAccumulator.usageData.model, usageDataAccumulator]]),
+    };
+
+    return new Promise<T>((resolve, reject) => {
+      UsageDataAccumulatorContext.storage.run(initialContext, async () => {
+        try {
+          const result = await fn();
+          resolve(result);
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+  }
+}

--- a/packages/conversation/src/fs/conversation_fs/ConversationFsModerator.ts
+++ b/packages/conversation/src/fs/conversation_fs/ConversationFsModerator.ts
@@ -65,6 +65,7 @@ export class ConversationFsModerator implements MessageModerator {
     this.logger = new Logger({ name: this.constructor.name, logLevel: this.logLevel });
   }
 
+  /** Only compatible with message content of type string. */
   observe(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
     let conversationFileSystemMessageIndex: number = -1;
     let conversationFileSystem: ConversationFs | undefined;
@@ -76,7 +77,9 @@ export class ConversationFsModerator implements MessageModerator {
       if (message.role == 'system' && message.content) {
         let parsedContent: any;
         try {
-          parsedContent = JSON.parse(message.content);
+          if (typeof message.content === 'string') {
+            parsedContent = JSON.parse(message.content);
+          }
         } catch (error) {}
         if (!parsedContent || !parsedContent['fileSystem']) {
           continue;

--- a/packages/conversation/src/history/MessageModerator.ts
+++ b/packages/conversation/src/history/MessageModerator.ts
@@ -1,6 +1,6 @@
 import { ChatCompletionMessageParam } from 'openai/resources/chat';
 
 export interface MessageModerator {
-  // given a set of messages, modify and return
+  /** Given a set of messages, modify and return. Only compatible with message content of type string. */
   observe(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[];
 }


### PR DESCRIPTION
update openai dependency version and include cachedPromptTokens in the usage data logs. Added the UsageDataAccumulatorContext in the generateResponseHelper to properly count tokens for recursive openai requests.